### PR TITLE
Added support for LightGBM models and an example under hummingbird

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -45,7 +45,7 @@ gmodel(**inputs)                # inference with provided inputs
 
 The simplest way to use GroqFlow is by calling `groqit()` with your model and a sample input.
 
-Returns a callable `GroqModel` instance that works like a PyTorch model (torch.nn.Module) or, when given scikit-learn or xgboost inputs, has `predict` and `predict_proba` methods.
+Returns a callable `GroqModel` instance that works like a PyTorch model (torch.nn.Module) or, when given scikit-learn, xgboost, or lightgbm inputs, has `predict` and `predict_proba` methods.
 
 **model:**
 
@@ -73,6 +73,9 @@ Returns a callable `GroqModel` instance that works like a PyTorch model (torch.n
   - The following xgboost models:
     - xgboost.XGBClassifier
     - xgboost.XGBRegressor
+  - The following lightgbm models:
+    - lightgbm.LGBMClassifier
+    - lightgbm.LGBMRegressor
 
 **inputs:**
 
@@ -357,7 +360,7 @@ Keras models built with `groqit()` return an instance of `class KerasModelWrappe
  - `KerasModelWrapper` is a callable object, similar to `tf.keras.Model` (i.e., `__call__()` executes the model's call function)
  - Tensors returned by `KerasModelWrapper` will be of type `tf.Tensor`
 
-scikit-learn and xgboost models built with `groqit()` return an instance of `class HummingbirdWrapper(GroqModel)`, which is the same as a `GroqModel` except:
+scikit-learn, xgboost, and lightgbm models built with `groqit()` return an instance of `class HummingbirdWrapper(GroqModel)`, which is the same as a `GroqModel` except:
  - There is a `predict` method returning estimator/classifier results mimicking the `predict` method of scikit-learn
  - There is a `predict_proba` method returning probabilities mimicking the `predict_proba` method of scikit-learn
  - The `run` method returns two outputs corresponding to the results of `predict` and `predict_proba`.
@@ -379,7 +382,7 @@ scikit-learn and xgboost models built with `groqit()` return an instance of `cla
 - The `inputs` argument is an unpacked dictionary where the keys correspond to the arguments of your model's forward function
 
 **`HummingbirdWrapper.predict(inputs: numpy.ndarray)`**
-- Predictions from a `GroqModel` based on a scikit-learn or xgboost model can be produced with the `predict` method.
+- Predictions from a `GroqModel` based on a scikit-learn, xgboost, or lightgbm model can be produced with the `predict` method.
 
 ### Example:
 
@@ -401,6 +404,7 @@ See:
  - `examples/onnx/hello_world.py`
  - `examples/hummingbird/xgbclassifier.py`
  - `examples/hummingbird/randomforest.py`
+ - `examples/hummingbird/lgbmclassifier.py`
 
 
 ---

--- a/examples/hummingbird/lgbmclassifier.py
+++ b/examples/hummingbird/lgbmclassifier.py
@@ -1,0 +1,37 @@
+"""
+The following example trains an LGBMClassifier against random data
+then compares the lightgbm result to GroqChip executed via GroqFlow.
+"""
+
+import numpy as np
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import classification_report
+from lightgbm import LGBMClassifier  # pylint: disable=import-error
+from groqflow import groqit
+
+batch_size = 320
+
+# Generate random points in a 10-dimensional space with binary labels
+np.random.seed(0)
+x = np.random.rand(1000, 10).astype(np.float32)
+y = np.random.randint(2, size=1000)
+
+# Perform a test/train split of the (random) dataset
+x_train, x_test, y_train, y_test = train_test_split(
+    x, y, test_size=batch_size, random_state=0
+)
+
+# Fit the model using standard sklearn patterns
+lgbm_model = LGBMClassifier(
+    n_estimators=10, max_depth=5, random_state=0
+)
+lgbm_model.fit(x_train, y_train)
+
+# Build the model
+groq_model = groqit(lgbm_model, {"input_0": x_test})
+
+# Display a report of standard classifier statistics
+print("LightGBM classification report")
+print(classification_report(y_test, lgbm_model.predict(x_test)))
+print("Groq classification report")
+print(classification_report(y_test, groq_model.predict(x_test)))

--- a/groqflow/justgroqit/hummingbird.py
+++ b/groqflow/justgroqit/hummingbird.py
@@ -36,6 +36,14 @@ try:
 except ImportError as e:
     xgboost_available = False
 
+try:
+    from lightgbm import LGBMClassifier
+    from lightgbm import LGBMRegressor
+
+    lightgbm_available = True
+except ImportError as e:
+    lightgbm_available = False
+
 
 def is_supported_sklearn_model(model) -> bool:
     return (
@@ -60,19 +68,23 @@ def is_supported_xgboost_model(model) -> bool:
     return isinstance(model, XGBClassifier) or isinstance(model, XGBRegressor)
 
 
+def is_supported_lightgbm_model(model) -> bool:
+    return isinstance(model, LGBMClassifier) or isinstance(model, LGBMRegressor)
+
+
 def is_supported_model(model) -> bool:
-    return (sklearn_available and is_supported_sklearn_model(model)) or (
-        xgboost_available and is_supported_xgboost_model(model)
-    )
+    return (sklearn_available and is_supported_sklearn_model(model)) or \
+        (xgboost_available and is_supported_xgboost_model(model)) or \
+        (lightgbm_available and is_supported_lightgbm_model(model))
 
 
 class ConvertHummingbirdModel(stage.GroqitStage):
     """
-    Stage that takes an SKLearn or XGBoost model instance, in state.model, and
+    Stage that takes an SKLearn, XGBoost, or LightGBM model instance, in state.model, and
     converts it to an ONNX file via Hummingbird.
 
     Expected inputs:
-     - state.model is an SKLearn or XGBoost model object
+     - state.model is an SKLearn, XGBoost, or LightGBM model object
      - state.inputs is a dict of the form {"input_0": <data>} where <data>
         is a numpy array as would be provided, e.g., to sklearn's predict method.
 
@@ -98,7 +110,7 @@ class ConvertHummingbirdModel(stage.GroqitStage):
         if not is_supported_model(state.model):
             msg = f"""
             The current stage (ConvertHummingbirdModel) is only compatible with
-            certain scikit-learn and xgboost models, however the stage
+            certain scikit-learn, xgboost, and lightgbm models, however the stage
             received an unsupported model of type {type(state.model)}.
 
             Support scikit-learn models:
@@ -118,6 +130,9 @@ class ConvertHummingbirdModel(stage.GroqitStage):
 
             Supported xgboost models:
               - xgboost.XGBClassifier
+
+            Supported lightgbm models:
+              - lightgbm.LGBMClassifier
             """
             raise exp.GroqitStageError(msg)
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "hummingbird-ml==0.4.4",
         "scikit-learn==1.1.1",
         "xgboost==1.6.1",
+        "lightgbm==3.3.5",
         "onnxruntime>=1.10.0",
         "paramiko==2.11.0",
         "torch>=1.12.1",


### PR DESCRIPTION
Tested as follows:

"""$ python lgbmclassifier.py 



GroqFlow is building "lgbmclassifier"
/home/ssettle/.local/lib/python3.8/site-packages/sklearn/experimental/enable_hist_gradient_boosting.py:16: UserWarning: Since version 1.0, it is not needed to import enable_hist_gradient_boosting anymore. HistGradientBoostingClassifier and HistGradientBoostingRegressor are now stable and can be normally imported from sklearn.ensemble.
  warnings.warn(or Op support   
    ✓ Converting model to ONNX with Hummingbird   
    ✓ Optimizing ONNX file   
    ✓ Checking for Op support   
    ✓ Compiling model   pport.. 
    ✓ Assembling model   

Woohoo! Saved to ~/.cache/groqflow/lgbmclassifier
LightGBM classification report
              precision    recall  f1-score   support

           0       0.54      0.54      0.54       174
           1       0.45      0.45      0.45       146

    accuracy                           0.50       320
   macro avg       0.49      0.49      0.49       320
weighted avg       0.50      0.50      0.50       320

Groq classification report
INFO:root:random seed: 131215178
INFO:root:cpp log level: 1
              precision    recall  f1-score   support
 
           0       0.54      0.54      0.54       174
           1       0.45      0.45      0.45       146

    accuracy                           0.50       320
   macro avg       0.49      0.49      0.49       320
weighted avg       0.50      0.50      0.50       320"""